### PR TITLE
Add sandwich logic for single start argument

### DIFF
--- a/morphs/sandwich/index.js
+++ b/morphs/sandwich/index.js
@@ -1,3 +1,15 @@
+const corpus = {
+  '<': '>',
+  '>': '<',
+  '[': ']',
+  ']': '[',
+  '(': ')',
+  ')': '(',
+  '{': '}',
+  '}': '{',
+};
+const corpusRegex = /(<|>|\[|\]|\(|\)|\{|\})/g;
+
 export default (Vue) => {
     Vue.filter('morph-sandwich', (value, start, end) => {
         return sandwich(value, start, end);
@@ -7,7 +19,18 @@ export default (Vue) => {
         return sandwich(value, start, end);
     };
 
+    function flip (str) {
+        return str.replace(corpusRegex, match => corpus[match])
+            .split('')
+            .reverse()
+            .join('');
+    }
+
     function sandwich(value, start, end) {
+        start = start || '';
+        end   = end   || flip(start);
+
         return `${ start }${ value }${ end }`;
     }
 };
+


### PR DESCRIPTION
`sandwich` usually expects three arguments: value, start, end.

A special case is added for when only start is provided: start is used
for both start and end, but in reverse.

Partially implements #5.

Examples:

```
sandwich('test', '...') // '...test...'
sandwich('test', '<--') // '<--test-->'
sandwich('test', '[(') // '[(test)]'
```