### PR TITLE
Start code for morph-url

### DIFF
--- a/morphs/url/index.js
+++ b/morphs/url/index.js
@@ -1,0 +1,15 @@
+// URL regex only recognizes letters, numbers, dot, slash, and hyphen for now
+// for simplicity
+const urlRegex
+  = /(https?:\/\/)?[A-Za-z0-9/.-]+\.[a-z]{2,6}\b\/?[A-Za-z0-9/.-]*/g;
+
+const surroundAnchor = str => `<a href="${str}">${str}</a>`;
+
+function morphUrl(str) {
+  if (!str || typeof str !== 'string') {
+    throw new Error('Cannot morph non-string.');
+  }
+
+  return str.replace(urlRegex, surroundAnchor);
+}
+


### PR DESCRIPTION
See #8.

Let's start with a general-purpose `morphUrl` function for now.

Moving forward, we can use this to regex-search-and-replace directly on an element's HTML from a directive, or we may want to go with some other direction -- just as long as we have the base logic.