### PR TITLE
fix(highlight): changed the span to mark, because of semantics

### DIFF
--- a/src/directives/highlight/index.js
+++ b/src/directives/highlight/index.js
@@ -8,6 +8,6 @@ export const highlight = (Vue) => {
     const highlightee = binding.value.split('::')[0];
     const highlighter = binding.value.split('::')[1];
     const regex = new RegExp(highlightee, 'gi');
-    el.innerHTML = str.replace(regex, `<span style="background-color: ${ highlighter }">${ highlightee }</span>`)
+    el.innerHTML = str.replace(regex, `<mark style="background-color: ${ highlighter }">${ highlightee }</mark>`)
   }
 };


### PR DESCRIPTION
Hi

there is a html tag which used to do highlighting. i think its kinda important because of the semantics and accessibility. and also easier to apply css on it 