### PR TITLE
refactor: use calendar years for age

### DIFF
--- a/src/filters/age/index.js
+++ b/src/filters/age/index.js
@@ -1,4 +1,4 @@
-import { differenceInYears } from 'date-fns';
+import { differenceInCalendarYears } from 'date-fns';
 
 export const age = (Vue) => {
   Vue.filter('morph-age', (value) => {
@@ -11,6 +11,6 @@ export const age = (Vue) => {
   };
 
   function calculateAge (date) {
-    return differenceInYears(Date.now(), date);
+    return differenceInCalendarYears(Date.now(), date);
   }
 };


### PR DESCRIPTION
Resolves #29.

Calendar year counting means age is counted by the end of the year,
which is what is usually meant when talking about age.

E.g. for a date of birth of 29 Nov 1995, with today being 27 Nov 2019,
age will be computed to 24 (2019 - 1995), even if 2 full days are still
needed to strictly meet 24 full years.