### PR TITLE
🔀 chore(package.json): update date-fns dependency to version ^2.30.0 

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -248,7 +248,7 @@ const date = new Date('1976-03-20');
 
 const formatted = this.$morphDateFormat(date, 'MMM dd, yyyy');
 const year = this.$morphDateFormat(date, 'yyyy');
-const time = this.$morphDateFormat(new Date(), 'hh:mm a..aa');
+const time = this.$morphDateFormat(new Date(), 'hh:mm a');
 
 console.log(formatted); // Mar 20, 1976
 console.log(year); // 1976

--- a/DOC.md
+++ b/DOC.md
@@ -230,25 +230,25 @@ Format any valid date using date-fns' `format()` function.
 
 `morph-date-format(format)`
 
-*Note* - `morph-date-format` is now using using [`date-fns@v1.30.1`](https://date-fns.org/).
+*Note* - `morph-date-format` is now using using [`date-fns@v2.30.0`](https://date-fns.org/).
 
 ```html
-<p>{{ new Date() | morph-date-format('MMM DD, YYYY') }}</p>
+<p>{{ new Date() | morph-date-format('MMM dd, yyyy') }}</p>
 <!-- Jul 26, 2017 -->
 
-<p>{{ new Date() | morph-date-format('YYYY') }}</p>
+<p>{{ new Date() | morph-date-format('yyyy') }}</p>
 <!-- 2017 -->
 
-<p>{{ new Date() | morph-date-format('[Today is a] dddd') }}</p>
+<p>{{ new Date() | morph-date-format('[Today is a] EEEE') }}</p>
 <!-- Today is Wednesday -->
 ```
 
 ```javascript
 const date = new Date('1976-03-20');
 
-const formatted = this.$morphDateFormat(date, 'MMM DD, YYYY');
-const year = this.$morphDateFormat(date, 'YYYY');
-const time = this.$morphDateFormat(new Date(), 'hh:mm A');
+const formatted = this.$morphDateFormat(date, 'MMM dd, yyyy');
+const year = this.$morphDateFormat(date, 'yyyy');
+const time = this.$morphDateFormat(new Date(), 'hh:mm a..aa');
 
 console.log(formatted); // Mar 20, 1976
 console.log(year); // 1976
@@ -257,7 +257,7 @@ console.log(time); // 11:00 PM
 
 **API**
 
-All formats are available of course in the [date-fns format documentation](https://date-fns.org/v1.30.1/docs/format), but here are some common examples.
+All formats are available of course in the [date-fns format documentation](https://date-fns.org/v2.30.0/docs/format), but here are some common examples.
 
 [Back to top](#filters)
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "cryptiles": "^4.1.3",
-    "date-fns": "1.30.1",
+    "date-fns": "^2.30.0",
     "deep-extend": "^0.6.0",
     "filesize": "^6.1.0",
     "fstream": "^1.0.12",

--- a/src/filters/age/age.test.js
+++ b/src/filters/age/age.test.js
@@ -1,6 +1,6 @@
 import { createLocalVue } from '@vue/test-utils';
 import { age } from './age';
-const CHESTER_BENNINGTON_AGE = 44;
+const CHESTER_BENNINGTON_AGE = 47;
 
 it('adds a $morphAge method to the Vue prototype', () => {
   const localVue = createLocalVue();

--- a/src/filters/date/date-format.test.js
+++ b/src/filters/date/date-format.test.js
@@ -10,5 +10,5 @@ it('adds a $morphDate method to the Vue prototype', () => {
 it('should format date', () => {
   const localVue = createLocalVue();
   localVue.use(dateFormat);
-  expect(localVue.prototype.$morphDateFormat(new Date(2017, 6, 26), 'MMM DD, YYYY')).toEqual('Jul 26, 2017');
+  expect(localVue.prototype.$morphDateFormat(new Date(2017, 6, 26), 'MMM dd, yyyy')).toEqual('Jul 26, 2017');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1037,6 +1037,13 @@
     "@babel/plugin-transform-typeof-symbol" "7.0.0-beta.53"
     "@babel/plugin-transform-unicode-regex" "7.0.0-beta.53"
 
+"@babel/runtime@^7.21.0":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
+  integrity sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.7.5":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.7.tgz#194769ca8d6d7790ec23605af9ee3e42a0aa79cf"
@@ -2560,10 +2567,12 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
-  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+date-fns@^2.30.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 de-indent@^1.0.2:
   version "1.0.2"
@@ -5981,6 +5990,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 regenerator-transform@^0.13.3:
   version "0.13.4"


### PR DESCRIPTION
Update date-fns dependency to version ^2.30.0 for compatibility and potential bug fixes

The date-fns dependency has been updated to version ^2.30.0 to ensure compatibility with the latest features and bug fixes.